### PR TITLE
Upgrade hickory-resolver to 0.26 and drop RUSTSEC-2026-0119 ignore

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -117,21 +117,4 @@ ignore = [
     # use bincode directly. Re-evaluate when surrealdb upgrades or when we
     # drop the optional surrealdb storage backend (jacs-surrealdb).
     { id = "RUSTSEC-2025-0141", reason = "transitive via surrealdb-core/surrealmx; no direct usage in JACS code; track surrealdb upstream" },
-
-    # hickory-proto 0.24.x O(n²) name-compression CPU exhaustion during
-    # message encoding. JACS uses hickory-resolver only as a DNS *client*
-    # doing TXT lookups for jacs.* records (jacs/src/dns/bootstrap.rs).
-    # The reachable input is the `jacs_agent_domain` field carried in a
-    # JACS document, which IS attacker-supplied during verify. Mitigations
-    # in place:
-    #   1. validate_dns_owner() in dns/bootstrap.rs rejects domains
-    #      exceeding RFC 1035 limits (253 bytes total, 63 per label) BEFORE
-    #      they reach hickory's encoder. This bounds n at ~127 labels for a
-    #      worst-case name, capping encoder CPU at O(n²) ≈ ~16k ops/query.
-    #   2. ensure_network_access() gates DNS lookups behind explicit
-    #      capability grants — disabling DNS lookups disables the path.
-    # Real fix: upgrade hickory-resolver to 0.26.x (separate PR — 0.26 is
-    # async-only and reshapes the Resolver builder API). Track upstream:
-    # https://github.com/hickory-dns/hickory-dns/security/advisories/GHSA-q2qq-hmj6-3wpp
-    { id = "RUSTSEC-2026-0119", reason = "client-side use; bounded by validate_dns_owner() pre-check (RFC 1035 limits) and DNS network capability gate; pending hickory 0.26 upgrade" },
 ]

--- a/jacs/Cargo.toml
+++ b/jacs/Cargo.toml
@@ -90,7 +90,7 @@ referencing = "0.33.0"
 futures-executor = "0.3.31"
 getset = "0.1.5"
 hex = "0.4"
-hickory-resolver = { version = "0.24", features = ["dnssec-ring"] }
+hickory-resolver = { version = "0.26", features = ["dnssec-ring"] }
 hkdf = "0.12"
 zeroize = "1.8"
 pbkdf2 = { version = "0.12", features = ["simple"] }
@@ -140,6 +140,7 @@ image = { version = "0.25", default-features = false, features = ["png", "jpeg"]
 crate-type = ["cdylib", "rlib"]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { version = "1.0", features = ["rt-multi-thread"] }
 ring = "0.17.9"
 reqwest = { version = "0.13.2", default-features = false, features = ["blocking", "json", "rustls"] }
 walkdir = "2.5.0"

--- a/jacs/src/dns/bootstrap.rs
+++ b/jacs/src/dns/bootstrap.rs
@@ -247,33 +247,48 @@ pub fn find_jacs_txt_record(records: Vec<String>, domain: &str) -> Result<String
 pub fn resolve_txt_dnssec(owner: &str) -> Result<String, JacsError> {
     use hickory_resolver::Resolver;
     use hickory_resolver::config::{ResolverConfig, ResolverOpts};
+    use hickory_resolver::net::runtime::TokioRuntimeProvider;
+    use hickory_resolver::proto::rr::RData;
     validate_dns_owner(owner)?;
     ensure_network_access(NetworkCapability::DnsLookup)?;
     let mut opts = ResolverOpts::default();
     opts.validate = true;
-    let resolver =
-        Resolver::new(ResolverConfig::default(), opts).map_err(|e| JacsError::DnsLookupFailed {
-            domain: owner.to_string(),
-            reason: format!("Resolver init failed: {e}"),
-        })?;
-    let resp = resolver
-        .txt_lookup(owner)
-        .map_err(|e| JacsError::DnsLookupFailed {
-            domain: owner.to_string(),
-            reason: format!("DNS lookup failed: {e}"),
+    let rt = tokio::runtime::Runtime::new().map_err(|e| JacsError::DnsLookupFailed {
+        domain: owner.to_string(),
+        reason: format!("Tokio runtime init failed: {e}"),
+    })?;
+    let resp = rt
+        .block_on(async {
+            let resolver =
+                Resolver::builder_with_config(ResolverConfig::default(), TokioRuntimeProvider::default())
+                    .with_options(opts)
+                    .build()
+                    .map_err(|e| JacsError::DnsLookupFailed {
+                        domain: owner.to_string(),
+                        reason: format!("Resolver init failed: {e}"),
+                    })?;
+            resolver
+                .txt_lookup(owner)
+                .await
+                .map_err(|e| JacsError::DnsLookupFailed {
+                    domain: owner.to_string(),
+                    reason: format!("DNS lookup failed: {e}"),
+                })
         })?;
     let mut records = Vec::new();
-    for rr in resp.iter() {
-        let mut record = String::new();
-        for part in rr.txt_data() {
-            record.push_str(&String::from_utf8(part.to_vec()).map_err(|e| {
-                JacsError::DnsRecordInvalid {
-                    domain: owner.to_string(),
-                    reason: format!("UTF-8 decode failed: {e}"),
-                }
-            })?);
+    for rec in resp.answers() {
+        if let RData::TXT(txt) = &rec.data {
+            let mut s = String::new();
+            for part in txt.txt_data.iter() {
+                s.push_str(&String::from_utf8(part.to_vec()).map_err(|e| {
+                    JacsError::DnsRecordInvalid {
+                        domain: owner.to_string(),
+                        reason: format!("UTF-8 decode failed: {e}"),
+                    }
+                })?);
+            }
+            records.push(s);
         }
-        records.push(record);
     }
     find_jacs_txt_record(records, owner)
 }
@@ -282,33 +297,48 @@ pub fn resolve_txt_dnssec(owner: &str) -> Result<String, JacsError> {
 pub fn resolve_txt_insecure(owner: &str) -> Result<String, JacsError> {
     use hickory_resolver::Resolver;
     use hickory_resolver::config::{ResolverConfig, ResolverOpts};
+    use hickory_resolver::net::runtime::TokioRuntimeProvider;
+    use hickory_resolver::proto::rr::RData;
     validate_dns_owner(owner)?;
     ensure_network_access(NetworkCapability::DnsLookup)?;
     let mut opts = ResolverOpts::default();
     opts.validate = false; // allow unsigned answers
-    let resolver =
-        Resolver::new(ResolverConfig::default(), opts).map_err(|e| JacsError::DnsLookupFailed {
-            domain: owner.to_string(),
-            reason: format!("Resolver init failed: {e}"),
-        })?;
-    let resp = resolver
-        .txt_lookup(owner)
-        .map_err(|e| JacsError::DnsLookupFailed {
-            domain: owner.to_string(),
-            reason: format!("DNS lookup failed: {e}"),
+    let rt = tokio::runtime::Runtime::new().map_err(|e| JacsError::DnsLookupFailed {
+        domain: owner.to_string(),
+        reason: format!("Tokio runtime init failed: {e}"),
+    })?;
+    let resp = rt
+        .block_on(async {
+            let resolver =
+                Resolver::builder_with_config(ResolverConfig::default(), TokioRuntimeProvider::default())
+                    .with_options(opts)
+                    .build()
+                    .map_err(|e| JacsError::DnsLookupFailed {
+                        domain: owner.to_string(),
+                        reason: format!("Resolver init failed: {e}"),
+                    })?;
+            resolver
+                .txt_lookup(owner)
+                .await
+                .map_err(|e| JacsError::DnsLookupFailed {
+                    domain: owner.to_string(),
+                    reason: format!("DNS lookup failed: {e}"),
+                })
         })?;
     let mut records = Vec::new();
-    for rr in resp.iter() {
-        let mut record = String::new();
-        for part in rr.txt_data() {
-            record.push_str(&String::from_utf8(part.to_vec()).map_err(|e| {
-                JacsError::DnsRecordInvalid {
-                    domain: owner.to_string(),
-                    reason: format!("UTF-8 decode failed: {e}"),
-                }
-            })?);
+    for rec in resp.answers() {
+        if let RData::TXT(txt) = &rec.data {
+            let mut s = String::new();
+            for part in txt.txt_data.iter() {
+                s.push_str(&String::from_utf8(part.to_vec()).map_err(|e| {
+                    JacsError::DnsRecordInvalid {
+                        domain: owner.to_string(),
+                        reason: format!("UTF-8 decode failed: {e}"),
+                    }
+                })?);
+            }
+            records.push(s);
         }
-        records.push(record);
     }
     find_jacs_txt_record(records, owner)
 }


### PR DESCRIPTION
## Summary
- Bumps hickory-resolver from 0.24 to 0.26 in `jacs/Cargo.toml`.
- Migrates `jacs/src/dns/bootstrap.rs` to the 0.26 async-only Resolver API: uses `Resolver::builder_with_config` + `TokioRuntimeProvider`, wrapped in `tokio::runtime::Runtime::new()?.block_on(...)` to preserve the existing sync callers.
- Adds `tokio` (rt-multi-thread) to `[target.'cfg(not(target_arch="wasm32"))'.dependencies]` so the DNS code can construct a blocking runtime on non-wasm targets (hickory-resolver 0.26 is async-only and requires a tokio runtime).
- Iterates TXT answers via `resp.answers()` + `RData::TXT(txt)` pattern to match the 0.26 `Lookup` API (the `TxtLookup` type was removed).
- Removes the RUSTSEC-2026-0119 ignore from `deny.toml` — fixed upstream by the encoder rewrite in hickory-proto 0.26.x.
- Keeps `validate_dns_owner()` pre-check (defense in depth, unrelated to CVE fix) and all 22 `dns::bootstrap` unit tests intact.

## Test plan
- [x] `cargo build -p jacs` — compiles cleanly
- [x] `cargo test -p jacs --lib dns::bootstrap` — 22 tests pass (including all 4 `validate_dns_owner_*` tests)
- [x] `cargo deny check advisories` — 0 errors after RUSTSEC-2026-0119 ignore removal

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZAmBDExotSoNUaye766AY)_